### PR TITLE
Update pom.xml  : Fix Cargo Tomcat Port Conflict by Configuring Custom HTTP Port

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,11 @@
                 <url>${cargo.maven.containerUrl}</url>
               </zipUrlInstaller>
             </container>
+            <configuration>
+               <properties>
+                <cargo.servlet.port>9090</cargo.servlet.port>
+               </properties>
+           </configuration>
             <daemon>
               <properties>
                 <cargo.daemon.url>http://localhost:18000</cargo.daemon.url>


### PR DESCRIPTION
This PR resolves the build failure caused by Cargo attempting to start Tomcat on the default port 8080, which conflicts with existing services (such as Jenkins).
The fix explicitly configures the Cargo Maven plugin to use a custom HTTP port (9090) for the embedded Tomcat instance.

Changes Included :
- Added cargo.servlet.port configuration to the Cargo Maven plugin.
- Prevents port collision during local and CI builds.
- Ensures smoother execution of integration tests in CI environments.

Impact : 
1. - No functional changes to the application.
2. Improves build stability and reliability.
3. Compatible with existing deployment setups.

